### PR TITLE
bugfix: add invenio_cache to testpaths in tool:pytest configuration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -65,5 +65,5 @@ ignore =
 
 [tool:pytest]
 addopts = --black --isort --pydocstyle --doctest-glob="*.rst" --doctest-modules --cov=invenio_cache --cov-report=term-missing
-testpaths = tests
+testpaths = tests invenio_cache
 filterwarnings = ignore::pytest.PytestDeprecationWarning


### PR DESCRIPTION
otherwise e.g. black is not tested in this directory
