### PR TITLE
add in-process cache decorator

### DIFF
--- a/invenio_cache/decorators.py
+++ b/invenio_cache/decorators.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2023 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Decorators to help with caching."""
 
-from __future__ import absolute_import, print_function
-
+import hashlib
+import threading
+import time
 from functools import wraps
 
 from .proxies import current_cache, current_cache_ext
@@ -31,3 +32,72 @@ def cached_unless_authenticated(timeout=50, key_prefix="default"):
         return wrapper
 
     return caching
+
+
+def cached_with_expiration(f):
+    """In-process cache function results, with optional expiration and entropy.
+
+    This decorator caches function results in-process and not in a distributed
+    cache, allowing for optional expiration.
+    Entries are based on function arguments and can include entropy to prevent
+    multiple keys from expiring simultaneously.
+    This implementation is highly inspired by the native functools.lru_cache. This
+    func can be replaced if/when lru_cache will accept an expiration time.
+
+    To tune cache ttl and entropy, the decorated function should have the following
+    kwargs:
+    :param cache_ttl (int): Expiration time in seconds. Default is 3600 seconds.
+    :param cache_entropy (bool): Add entropy to cache expiration. Default is True.
+    """
+    cache = {}
+    cache_lock = threading.Lock()
+    hits = misses = 0
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        """Wrapper."""
+        nonlocal hits, misses
+        cache_ttl = kwargs.pop("cache_ttl", 3600)
+        with_entropy = kwargs.pop("cache_entropy", True)
+
+        # Create a hashable key that includes args and the sorted kwargs
+        key = (args) + tuple(sorted(kwargs.items()))
+
+        entropy = 0
+        if with_entropy:
+            # calculate entropy
+            key_str = str(key)
+            # calculate 2-digits int from args/kwargs to prevent keys created
+            # at the same time from expiring simultaneously
+            entropy = int(hashlib.md5(key_str.encode()).hexdigest(), 16) % 100
+
+        now = time.time()
+        with cache_lock:
+            cache_hit = (
+                key in cache and now - cache[key][1] < cache_ttl
+            )  # exists and not expired
+            if cache_hit:
+                hits += 1
+                return cache[key][0]
+            else:
+                result = f(*args, **kwargs)
+                cache[key] = (result, now + entropy)
+                misses += 1
+                return result
+
+    def cache_info():
+        """Report cache statistics."""
+        nonlocal hits, misses
+        with cache_lock:
+            return (hits, misses)
+
+    def cache_clear():
+        """Clear the cache."""
+        nonlocal hits, misses
+        with cache_lock:
+            cache.clear()
+            hits = misses = 0
+
+    wrapper.cache_clear = cache_clear
+    wrapper.cache_info = cache_info
+    return wrapper

--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,12 @@ install_requires =
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0,<0.3.10
+    pytest-black>=0.3.0
     mock>=2.0.0
     redis>=2.10.5
     pytest-invenio>=1.4.0
-    invenio-accounts>=2.0.0.dev10
+    pytest-mock>=1.6.0
+    invenio-accounts>=2.0.0
     Sphinx>=3
 
 [options.entry_points]

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,19 +1,23 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of Invenio.
-# Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2017-2023 CERN.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
 """Module tests."""
 
-from __future__ import absolute_import, print_function
+import hashlib
+import time
+
+import pytest
 
 from invenio_cache import cached_unless_authenticated
+from invenio_cache.decorators import cached_with_expiration
 
 
-def test_decorator(base_app, ext):
+def test_decorator_cached_unless_authenticated(base_app, ext):
     """Test cached_unless_authenticated."""
     base_app.config["MYVAR"] = "1"
     ext.is_authenticated_callback = lambda: False
@@ -41,3 +45,85 @@ def test_decorator(base_app, ext):
         base_app.config["MYVAR"] = "2"
         # We are NOT getting a cached version
         assert c.get("/").get_data(as_text=True) == "2"
+
+
+def test_decorator_cached_with_expiration(mocker):
+    """Test cached_with_expiration decorator."""
+    one_hour = 3600
+
+    @cached_with_expiration
+    def get_cached_only_args(arg1):
+        return arg1
+
+    @cached_with_expiration
+    def get_cached_only_kwargs(kwarg1="test"):
+        return kwarg1
+
+    @cached_with_expiration
+    def get_cached_args_kwargs(arg1, kwarg1="test"):
+        return arg1 + kwarg1
+
+    # reset
+    get_cached_only_args.cache_clear()
+
+    # hit/miss tests without default TTL and no entropy
+    assert get_cached_only_args("value1", cache_entropy=False) == "value1"
+    hits, misses = get_cached_only_args.cache_info()
+    assert hits == 0
+    assert misses == 1
+    assert get_cached_only_args("value1", cache_entropy=False) == "value1"
+    hits, misses = get_cached_only_args.cache_info()
+    assert hits == 1
+    assert misses == 1
+
+    expired = time.time() + one_hour + 10
+    with mocker.patch("time.time", return_value=expired):
+        # cache miss because it expired
+        assert get_cached_only_args("value1") == "value1"
+        hits, misses = get_cached_only_args.cache_info()
+        assert hits == 1
+        assert misses == 2
+
+    # tests args/kwargs
+    assert get_cached_only_args("value1") == "value1"
+    assert get_cached_only_args((1, 2)) == (1, 2)
+    assert get_cached_only_kwargs(kwarg1="value2") == "value2"
+    assert get_cached_only_kwargs(kwarg1=(1, 2)) == (1, 2)
+    assert get_cached_args_kwargs((1, 2), kwarg1=(3, 4)) == (1, 2, 3, 4)
+
+    with pytest.raises(TypeError):  # TypeError: unhashable type:
+        get_cached_only_args([1, 3])
+        get_cached_only_kwargs(kwarg1=[1, 3])
+
+    # reset
+    get_cached_only_args.cache_clear()
+
+    # test entropy
+    now = time.time()
+
+    assert get_cached_only_args("value1") == "value1"
+    hits, misses = get_cached_only_args.cache_info()
+    assert hits == 0
+    assert misses == 1
+
+    still_valid = now + one_hour
+    with mocker.patch("time.time", return_value=still_valid):
+        assert get_cached_only_args("value1") == "value1"
+        hits, misses = get_cached_only_args.cache_info()
+        assert hits == 1
+        assert misses == 1
+
+    entropy = int(hashlib.md5(str(("value1",)).encode()).hexdigest(), 16) % 100
+    still_valid_with_entropy = still_valid + entropy - 1  # -1 sec to be still valid
+    with mocker.patch("time.time", return_value=still_valid_with_entropy):
+        assert get_cached_only_args("value1") == "value1"
+        hits, misses = get_cached_only_args.cache_info()
+        assert hits == 2
+        assert misses == 1
+
+    expired = still_valid + entropy
+    with mocker.patch("time.time", return_value=expired):
+        assert get_cached_only_args("value1") == "value1"
+        hits, misses = get_cached_only_args.cache_info()
+        assert hits == 2
+        assert misses == 2


### PR DESCRIPTION
* add a new decorator to cache function results in-process, with expiration.