### PR TITLE
fix: pkg_resources DeprecationWarning

### DIFF
--- a/invenio_cache/ext.py
+++ b/invenio_cache/ext.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,7 +11,6 @@
 
 from __future__ import absolute_import, print_function
 
-import pkg_resources
 from flask_caching import Cache
 from werkzeug.utils import import_string
 
@@ -46,11 +46,10 @@ def _callback_factory(callback_imp):
     """Factory for creating a is authenticated callback."""
     if callback_imp is None:
         try:
-            pkg_resources.get_distribution("flask-login")
             from flask_login import current_user
 
             return lambda: current_user.is_authenticated
-        except pkg_resources.DistributionNotFound:
+        except ImportError:
             return lambda: False
     elif isinstance(callback_imp, string_types):
         return import_string(callback_imp)

--- a/tests/test_invenio_cache.py
+++ b/tests/test_invenio_cache.py
@@ -2,6 +2,7 @@
 #
 # This file is part of Invenio.
 # Copyright (C) 2017-2018 CERN.
+# Copyright (C) 2025 Graz University of Technology.
 #
 # Invenio is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -10,9 +11,7 @@
 
 from __future__ import absolute_import, print_function
 
-import pkg_resources
 from flask import Flask
-from flask_login import current_user
 from mock import patch
 
 from invenio_cache import (
@@ -76,8 +75,15 @@ def test_callback():
     )
 
 
-@patch("pkg_resources.get_distribution")
-def test_callback_no_login(get_distribution):
+@patch("builtins.__import__")
+def test_callback_no_login(mock_import):
     """Test callback factory (no flask-login)."""
-    get_distribution.side_effect = pkg_resources.DistributionNotFound
+
+    # Mock ImportError when trying to import flask_login
+    def side_effect(name, *args, **kwargs):
+        if name == "flask_login":
+            raise ImportError("No module named 'flask_login'")
+        return __import__(name, *args, **kwargs)
+
+    mock_import.side_effect = side_effect
     assert _callback_factory(None)() is False


### PR DESCRIPTION
* UserWarning: pkg_resources is deprecated as an API. See
  https://setuptools.pypa.io/en/latest/pkg_resources.html. The
  pkg_resources package is slated for removal as early as 2025-11-30.
  Refrain from using this package or pin to Setuptools<81.
